### PR TITLE
Fix spelling error on variable `resoruce_group_creation_enabled` -> `…

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Default:
 }
 ```
 
-### <a name="input_resoruce_group_creation_enabled"></a> [resoruce\_group\_creation\_enabled](#input\_resoruce\_group\_creation\_enabled)
+### <a name="input_resource_group_creation_enabled"></a> [resource\_group\_creation\_enabled](#input\_resource\_group\_creation\_enabled)
 
 Description: This variable controls whether or not the resource group should be created. If set to false, the resource group must be created elsewhere and the resource group name must be provided to the module. If set to true, the resource group will be created by the module using the name provided in `resource_group_name`.
 

--- a/examples/with-vnet-link-existing-rg/README.md
+++ b/examples/with-vnet-link-existing-rg/README.md
@@ -70,7 +70,7 @@ module "test" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  resoruce_group_creation_enabled = false
+  resource_group_creation_enabled = false
 
   virtual_network_resource_ids_to_link_to = {
     "vnet1" = {

--- a/examples/with-vnet-link-existing-rg/main.tf
+++ b/examples/with-vnet-link-existing-rg/main.tf
@@ -62,7 +62,7 @@ module "test" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  resoruce_group_creation_enabled = false
+  resource_group_creation_enabled = false
 
   virtual_network_resource_ids_to_link_to = {
     "vnet1" = {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "this" {
-  count = var.resoruce_group_creation_enabled ? 1 : 0
+  count = var.resource_group_creation_enabled ? 1 : 0
 
   location = var.location
   name     = var.resource_group_name
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 data "azurerm_resource_group" "this" {
-  count = var.resoruce_group_creation_enabled ? 0 : 1
+  count = var.resource_group_creation_enabled ? 0 : 1
 
   name = var.resource_group_name
 }
@@ -18,7 +18,7 @@ module "avm_res_network_privatednszone" {
   source  = "Azure/avm-res-network-privatednszone/azurerm"
   version = "0.1.2"
 
-  resource_group_name = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].name : var.resource_group_name
+  resource_group_name = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].name : var.resource_group_name
   domain_name         = each.value.zone_value.zone_name
 
   virtual_network_links = each.value.has_vnet ? { for vnet in each.value.vnets : vnet.vnet_key => {
@@ -39,7 +39,7 @@ resource "azurerm_management_lock" "this" {
 
   lock_level = var.lock.kind
   name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
-  scope      = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  scope      = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
   notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
 }
 
@@ -47,7 +47,7 @@ resource "azurerm_role_assignment" "this" {
   for_each = var.resource_group_role_assignments
 
   principal_id                           = each.value.principal_id
-  scope                                  = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  scope                                  = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version
   delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,5 +5,5 @@ output "combined_private_link_private_dns_zones_replaced_with_vnets_to_link" {
 
 output "resource_group_resource_id" {
   description = "The resource ID of the resource group that the Private DNS Zones are deployed into."
-  value       = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  value       = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -298,7 +298,7 @@ DESCRIPTION
   nullable    = false
 }
 
-variable "resoruce_group_creation_enabled" {
+variable "resource_group_creation_enabled" {
   type        = bool
   default     = true
   description = "This variable controls whether or not the resource group should be created. If set to false, the resource group must be created elsewhere and the resource group name must be provided to the module. If set to true, the resource group will be created by the module using the name provided in `resource_group_name`."


### PR DESCRIPTION
…resource_group_creation_enabled`

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
